### PR TITLE
タグページのカード間隔をトップと統一

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,16 +33,18 @@ const [posts, rankedPosts, tags, numberOfPages] = await Promise.all([
       posts.length === 0 ? (
         <NoContents contents={posts} />
       ) : (
-        posts.map((post) => (
-          <div class={styles.post} key={post.Slug}>
-            <PostTitle post={post} />
-            <PostDate post={post} />
-            <PostTags post={post} />
-            <PostFeaturedImage post={post} />
-            <PostExcerpt post={post} />
-            <ReadMoreLink post={post} />
-          </div>
-        ))
+        <div class={styles.postList}>
+          {posts.map((post) => (
+            <article class={styles.post} key={post.Slug}>
+              <PostFeaturedImage post={post} />
+              <PostTitle post={post} />
+              <PostDate post={post} />
+              <PostTags post={post} />
+              <PostExcerpt post={post} />
+              <ReadMoreLink post={post} />
+            </article>
+          ))}
+        </div>
       )
     }
 

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -4,7 +4,6 @@ import {
   getRankedPosts,
   getAllTags,
   getNumberOfPages,
-  getPostsByPage,
 } from '../../../lib/notion/client.ts'
 import Layout from '../../../layouts/Layout.astro'
 import NoContents from '../../../components/NoContents.astro'
@@ -49,16 +48,18 @@ const [posts, rankedPosts, tags, numberOfPages] = await Promise.all([
       posts.length === 0 ? (
         <NoContents contents={posts} />
       ) : (
-        posts.map((post) => (
-          <div class={styles.post} key={post.Slug}>
-            <PostTitle post={post} />
-            <PostDate post={post} />
-            <PostTags post={post} />
-            <PostFeaturedImage post={post} />
-            <PostExcerpt post={post} />
-            <ReadMoreLink post={post} />
-          </div>
-        ))
+        <div class={styles.postList}>
+          {posts.map((post) => (
+            <article class={styles.post} key={post.Slug}>
+              <PostTitle post={post} />
+              <PostDate post={post} />
+              <PostTags post={post} />
+              <PostFeaturedImage post={post} />
+              <PostExcerpt post={post} />
+              <ReadMoreLink post={post} />
+            </article>
+          ))}
+        </div>
       )
     }
 

--- a/src/pages/posts/tag/[tag].astro
+++ b/src/pages/posts/tag/[tag].astro
@@ -50,16 +50,18 @@ const currentTag = posts[0].Tags.find((t) => t.name === tag)
       posts.length === 0 ? (
         <NoContents contents={posts} />
       ) : (
-        posts.map((post) => (
-          <div class={styles.post} key={post.Slug}>
-            <PostDate post={post} />
-            <PostTags post={post} />
-            <PostTitle post={post} />
-            <PostFeaturedImage post={post} />
-            <PostExcerpt post={post} />
-            <ReadMoreLink post={post} />
-          </div>
-        ))
+        <div class={styles.postList}>
+          {posts.map((post) => (
+            <article class={styles.post} key={post.Slug}>
+              <PostDate post={post} />
+              <PostTags post={post} />
+              <PostTitle post={post} />
+              <PostFeaturedImage post={post} />
+              <PostExcerpt post={post} />
+              <ReadMoreLink post={post} />
+            </article>
+          ))}
+        </div>
       )
     }
 

--- a/src/pages/posts/tag/[tag]/page/[page].astro
+++ b/src/pages/posts/tag/[tag]/page/[page].astro
@@ -66,16 +66,18 @@ const currentTag = posts[0].Tags.find((t) => t.name === tag)
       posts.length === 0 ? (
         <NoContents contents={posts} />
       ) : (
-        posts.map((post) => (
-          <div class={styles.post} key={post.Slug}>
-            <PostDate post={post} />
-            <PostTags post={post} />
-            <PostTitle post={post} />
-            <PostFeaturedImage post={post} />
-            <PostExcerpt post={post} />
-            <ReadMoreLink post={post} />
-          </div>
-        ))
+        <div class={styles.postList}>
+          {posts.map((post) => (
+            <article class={styles.post} key={post.Slug}>
+              <PostDate post={post} />
+              <PostTags post={post} />
+              <PostTitle post={post} />
+              <PostFeaturedImage post={post} />
+              <PostExcerpt post={post} />
+              <ReadMoreLink post={post} />
+            </article>
+          ))}
+        </div>
       )
     }
 

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -31,7 +31,9 @@
   border-radius: 16px;
   background-color: rgba(255, 255, 255, 0.95);
   box-shadow: 0 18px 35px -25px rgba(0, 0, 0, 0.6);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .post:hover {

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -12,11 +12,35 @@
   }
 }
 
-.post {
+.postList {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
   margin: 0 auto 40px;
+  max-width: 720px;
+  width: 100%;
 }
+
+.post {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  padding: 24px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 16px;
+  background-color: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 18px 35px -25px rgba(0, 0, 0, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.post:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 40px -20px rgba(0, 0, 0, 0.65);
+}
+
 .post footer {
-  margin-top: 0.5rem;
+  margin-top: auto;
   padding: 0;
   border: 0;
 }


### PR DESCRIPTION
## 概要
- タグ別記事一覧をカードリスト用コンテナで包み、カード間隔をトップページと統一
- タグ別ページネーションでも同様にカードをラップして余白を確保
- 記事一覧ページの重複インポートを整理

## テスト
- npm run build *(Notion API への接続エラーにより失敗)*

------
https://chatgpt.com/codex/tasks/task_e_69031e1b699c83338beee70e65a01f1a